### PR TITLE
Fix project and folder IAM condition errors

### DIFF
--- a/Google/resource-manager/folder/locals.tf
+++ b/Google/resource-manager/folder/locals.tf
@@ -18,14 +18,14 @@ locals {
   }
 
   #Remove duplicate bindings from folder_iam_merged and ensure all IAM binding fields are present
-  #If folder_iam in components.specs doesn't exist the ones from components.copied will be copied into the config in
-  #both the definition of both local.folder_specs and local.folder_iam_merged
+  #If folder_iam in components.specs doesn't exist the ones from components.common will be copied into the config in
+  #both the definition of local.folder_specs and local.folder_iam_merged
   folders_iam = { for folder, policy in local.folders_iam_merged : folder =>
     distinct([
       for binding in policy : {
         role = lookup(binding, "role", null)
         members = lookup(binding, "members", null)
-        condition = lookup(binding, "condition", { condition = null })
+        condition = lookup(binding, "condition", {})
       }
     ])
   }

--- a/Google/resource-manager/folder/main.tf
+++ b/Google/resource-manager/folder/main.tf
@@ -19,7 +19,7 @@ data "google_iam_policy" "self" {
       members = lookup(binding.value, "members", null)
       //noinspection HILUnresolvedReference
       dynamic "condition" {
-        for_each = lookup(binding.value, "condition", { condition = null }) == { condition = null } ? {} : { condition : binding.value.condition }
+        for_each = length(lookup(binding.value, "condition", {})) == 0 ? {} : { condition : binding.value.condition }
         content {
           title       = lookup(condition.value, "title", null)
           description = lookup(condition.value, "description", null)

--- a/Google/resource-manager/project/locals.tf
+++ b/Google/resource-manager/project/locals.tf
@@ -23,14 +23,14 @@ locals {
   }
 
   #Remove duplicate bindings from project_iam_merged and ensure all IAM binding fields are present
-  #If project_iam in components.specs doesn't exist the ones from components.copied will be copied into the config in
-  #both the definition of both local.projects_specs and local.project_iam_merged
+  #If project_iam in components.specs doesn't exist the ones from components.common will be copied into the config in
+  #both the definition of local.projects_specs and local.project_iam_merged
   projects_iam = { for project, policy in local.projects_iam_merged : project =>
     distinct([
       for binding in policy : {
         role = lookup(binding, "role", null)
         members = lookup(binding, "members", null)
-        condition = lookup(binding, "condition", {condition = null})
+        condition = lookup(binding, "condition", {})
       }
     ])
   }

--- a/Google/resource-manager/project/main.tf
+++ b/Google/resource-manager/project/main.tf
@@ -26,7 +26,7 @@ data "google_iam_policy" "self" {
       members = lookup(binding.value, "members", null)
       //noinspection HILUnresolvedReference
       dynamic "condition" {
-      for_each = lookup(binding.value, "condition", { condition = null }) == { condition = null } ? {} : { condition : binding.value.condition }
+        for_each = length(lookup(binding.value, "condition", {})) == 0 ? {} : { condition : binding.value.condition }
         content {
           title       = lookup(condition.value, "title", null)
           description = lookup(condition.value, "description", null)


### PR DESCRIPTION
The current logic used for setting IAM policy in Google projects and folders works if there are no conditions in the bindings, or if all the bindings have conditions, but will error if there are some bindings with and some without conditions.  
This fixes the logic of the `condition` block so that it no longer errors when setting a policy that has bindings with and without conditions