### PR TITLE
Add essential contacts blocks for Google Projects and Folders

### DIFF
--- a/Google/resource-manager/folder/README.md
+++ b/Google/resource-manager/folder/README.md
@@ -46,7 +46,33 @@ The IAM policy for each defined project can be set in the `folder_iam`.
 * `members` (required): Identities who the role is granted to (see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members) for format)
 * `condition` (optional): IAM condition for role assignment (see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#nested_condition) for configuration)
 
-### Example
+### Advisory Notifications
+[Advisory notifications](https://cloud.google.com/advisory-notifications/docs/overview) provide communications about
+security events on Google Cloud Platform to configured essential contacts.
+Essential contacts to receive these notifications for a folder can be configured using an `essential_contacts` block.  
+The `essential_contacts` block has the following attributes:
+* `language_tag` - Language the notifications should be sent in (defaults to en-GB)
+* `contacts` - A map of contacts and a list of the notification categories they should receive
+
+Full notification types can be found in the [google documentation](https://cloud.google.com/resource-manager/docs/managing-notification-contacts).  
+Example `essential_contacts` block:
+```yaml
+essential_contacts:
+  language_tag: en-GB
+  contacts:
+    admin-team@company.com: ["ALL"]
+    business-team@company.com: 
+      - BILLING
+      - LEGAL
+    security-team@company.com: 
+      - SECURITY
+      - TECHNICAL
+    platform-team@company.com:
+      - TECHNICAL
+```
+
+
+### Full Example
 ```yaml
 components:
   common:
@@ -60,6 +86,11 @@ components:
         - role: "roles/viewer"
           members:
             - "user:info@example.com"
+      essential_contacts:
+        contacts:
+          security-team@company.com:
+            - SECURITY
+            - TECHNICAL
     department-2:
       display_name: "Department-Bob"
       folder_iam:

--- a/Google/resource-manager/folder/locals.tf
+++ b/Google/resource-manager/folder/locals.tf
@@ -29,4 +29,9 @@ locals {
       }
     ])
   }
+
+  folders_essential_contacts = {
+    for folder, specs in local.folders_specs: folder => specs.essential_contacts
+    if lookup(specs, "essential_contacts", null) != null
+  }
 }

--- a/Google/resource-manager/folder/main.tf
+++ b/Google/resource-manager/folder/main.tf
@@ -29,3 +29,11 @@ data "google_iam_policy" "self" {
     }
   }
 }
+
+module essential_contacts {
+  source = "../sub_modules/essential_contacts"
+  for_each = local.folders_essential_contacts
+  parent_id = google_folder.self[each.key].name
+  language_tag = lookup(each.value, "language_tag", "en-GB")
+  essential_contacts = lookup(each.value, "contacts", {})
+}

--- a/Google/resource-manager/project/README.md
+++ b/Google/resource-manager/project/README.md
@@ -124,7 +124,33 @@ If a role required for enabling services is set in the projects IAM policy durin
 a default delay of 2 minutes is set, allowing for propagation of permissions.   
 This delay can be updated using the `enable_service_delay` attribute in the `components.commons` section.
 
-### Example  
+### Advisory Notifications
+[Advisory notifications](https://cloud.google.com/advisory-notifications/docs/overview) provide communications about 
+security events on Google Cloud Platform to configured essential contacts.
+Essential contacts to receive these notifications for a project can be configured using an `essential_contacts` block.  
+The `essential_contacts` block has the following attributes:
+* `language_tag` - Language the notifications should be sent in (defaults to en-GB)
+* `contacts` - A map of contacts and a list of the notification categories they should receive
+
+Full notification types can be found in the [google documentation](https://cloud.google.com/resource-manager/docs/managing-notification-contacts)
+
+Example `essential_contacts` block:
+```yaml
+essential_contacts:
+  language_tag: en-GB
+  contacts:
+    admin-team@company.com: ["ALL"]
+    business-team@company.com: 
+      - BILLING
+      - LEGAL
+    security-team@company.com: 
+      - SECURITY
+      - TECHNICAL
+    platform-team@company.com:
+      - TECHNICAL
+```
+
+### Full Example  
 ```yaml
 components:
   common:

--- a/Google/resource-manager/project/locals.tf
+++ b/Google/resource-manager/project/locals.tf
@@ -54,5 +54,11 @@ locals {
   projects_services = zipmap([for service in local.projects_services_merged: replace("${service.project}_${split(".", service.service)[0]}", "-", "_")], local.projects_services_merged)
 
   enable_service_delay = length(local.projects_services) == 0 ? null : length(local.projects_iam) == 0 ? "0m" : lookup(local.projects_components_common, "enable_service_delay", "2m")
+
+  projects_essential_contacts = {
+    for project, specs in local.projects_specs: project => specs.essential_contacts
+    if lookup(specs, "essential_contacts", null) != null
+  }
+
 }
 

--- a/Google/resource-manager/project/main.tf
+++ b/Google/resource-manager/project/main.tf
@@ -53,3 +53,11 @@ resource google_project_service self {
   disable_on_destroy = each.value.disable_on_destroy
   disable_dependent_services = each.value.disable_dependent_services
 }
+
+module essential_contacts {
+  source = "../sub_modules/essential_contacts"
+  for_each = local.projects_essential_contacts
+  parent_id = google_project.self[each.key].id
+  language_tag = lookup(each.value, "language_tag", "en-GB")
+  essential_contacts = lookup(each.value, "contacts", {})
+}

--- a/Google/resource-manager/sub_modules/essential_contacts/main.tf
+++ b/Google/resource-manager/sub_modules/essential_contacts/main.tf
@@ -1,0 +1,7 @@
+resource google_essential_contacts_contact self {
+  for_each = var.essential_contacts
+  parent = var.parent_id
+  email = each.key
+  language_tag = var.language_tag
+  notification_category_subscriptions = each.value
+}

--- a/Google/resource-manager/sub_modules/essential_contacts/vars.tf
+++ b/Google/resource-manager/sub_modules/essential_contacts/vars.tf
@@ -1,0 +1,21 @@
+variable essential_contacts {
+  type = map(list(string))
+  default = {}
+  validation {
+    condition = alltrue([for key in keys(var.essential_contacts): (length(regexall("\\w*@\\w*\\.\\w*", key)) > 0)])
+    error_message = "Key for map must be valid email address."
+  }
+}
+
+variable language_tag {
+  type = string
+  default = "en-GB"
+}
+
+variable parent_id {
+  type = string
+  validation {
+    condition = contains(["folders", "projects", "organizations"], split("/", var.parent_id)[0])
+    error_message = "Invalid parent id, must take format 'organizations/{organization_id}', 'folders/{folder_id}' or 'projects/{project_id}'"
+  }
+}

--- a/tests/gcp/unit_tests/google_folder/main.tf
+++ b/tests/gcp/unit_tests/google_folder/main.tf
@@ -5,3 +5,14 @@ data external test_folder_parent_id {
 output folder_parent_id {
   value = data.external.test_folder_parent_id.result
 }
+
+data external test_essential_contacts{
+  query = {
+    for project, essential_contacts in local.folders_essential_contacts: project => keys(lookup(essential_contacts, "contacts", {}))[0]
+  }
+  program = ["python", "${path.module}/test_essential_contacts.py"]
+}
+
+output test_essential_contacts {
+  value = data.external.test_essential_contacts.result
+}

--- a/tests/gcp/unit_tests/google_folder/resources/folders.yaml
+++ b/tests/gcp/unit_tests/google_folder/resources/folders.yaml
@@ -5,6 +5,9 @@ components:
       - role: "roles/owner"
         members:
           - "user:owner@example.com"
+    essential_contacts:
+      contacts:
+        user@foo.com: ["ALL"]
   specs:
     staging:
       folder_iam:

--- a/tests/gcp/unit_tests/google_folder/test_essential_contacts.py
+++ b/tests/gcp/unit_tests/google_folder/test_essential_contacts.py
@@ -1,0 +1,23 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests that project essential contacts get configured
+"""
+
+expected_data = {
+    "staging": 'user@foo.com',
+    "department-2": "user@foo.com"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/google_project/main.tf
+++ b/tests/gcp/unit_tests/google_project/main.tf
@@ -48,3 +48,15 @@ data external test_services {
 output test_services {
   value = data.external.test_services.result
 }
+
+
+data external test_essential_contacts{
+  query = {
+    for project, essential_contacts in local.projects_essential_contacts: project => keys(lookup(essential_contacts, "contacts", {}))[0]
+  }
+  program = ["python", "${path.module}/test_essential_contacts.py"]
+}
+
+output test_essential_contacts {
+  value = data.external.test_essential_contacts.result
+}

--- a/tests/gcp/unit_tests/google_project/resources/projects.yaml
+++ b/tests/gcp/unit_tests/google_project/resources/projects.yaml
@@ -38,9 +38,18 @@ components:
             title: "expires_after_2019_12_31"
             description: "Expiring at midnight of 2019-12-31"
             expression: "request.time < timestamp(\"2020-01-01T00:00:00Z\")"
+      essential_contacts:
+        language_tag: "en-US"
+        contacts:
+          user@foo.com:
+            - TECHNICAL
+            - SECURITY
     test-project:
       project_id: test-project-123
       services:
         - service: recommender.googleapis.com
           disable_on_destroy: false
+      essential_contacts:
+        contacts:
+          user@bar.com: ["ALL"]
 

--- a/tests/gcp/unit_tests/google_project/test_essential_contacts.py
+++ b/tests/gcp/unit_tests/google_project/test_essential_contacts.py
@@ -1,0 +1,23 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests that project essential contacts get configured
+"""
+
+expected_data = {
+    "staging-sandbox": 'user@foo.com',
+    "test-project": "user@bar.com"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)


### PR DESCRIPTION
This adds the option to configure essential contacts for Advisory Notifications in Google Project and Folder modules.
* Created `sub_modules` directory in the `resource-manager` directory, for modules used by MCCF adapters. This is so that the essential_contacts module would not get confused as a separate MCCF module 
* Created `essential_contacts` module in the `sub_modules` directory, based on the [Google implementation](https://github.com/terraform-google-modules/terraform-google-project-factory/tree/v14.1.0/modules/essential_contacts) 
* Implemented Essential Contacts module in Google Projects and Google Folder modules
* Updated unit tests and documentation