### PR TITLE
Temporarily remove billing resources

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -220,21 +220,21 @@ jobs:
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan
 
-      - name: Deploy GKE clusters
-        id : deploy-gke
-        env:
-          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
-        run: |
-          cd gke
-          terraform init
-          terraform plan -out="./plan.tfplan"
-          terraform apply plan.tfplan
-
-      - name: Destroy GKE clusters
-        if: steps.deploy-gke.outcome != 'skipped'
-        run: |
-          cd gke
-          terraform destroy -auto-approve
+#      - name: Deploy GKE clusters
+#        id : deploy-gke
+#        env:
+#          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
+#        run: |
+#          cd gke
+#          terraform init
+#          terraform plan -out="./plan.tfplan"
+#          terraform apply plan.tfplan
+#
+#      - name: Destroy GKE clusters
+#        if: steps.deploy-gke.outcome != 'skipped'
+#        run: |
+#          cd gke
+#          terraform destroy -auto-approve
 
       - name: Destroy Google Service Accounts
         if: steps.deploy-GSAs.outcome != 'skipped'

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -220,6 +220,7 @@ jobs:
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan
 
+# TODO: re-enable steps when billing is configured
 #      - name: Deploy GKE clusters
 #        id : deploy-gke
 #        env:

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -20,10 +20,10 @@ components:
         key-1: overwrite-value
         key-2: value-2
       auto_create_network: true
-      services:
-        - service: container.googleapis.com
-          disable_dependent_services: true
-        - service: gkebackup.googleapis.com
+#      services:
+#        - service: container.googleapis.com
+#          disable_dependent_services: true
+#        - service: gkebackup.googleapis.com
     test-project:
       project_id: mcp-test-project-<project_date>
       auto_create_network: true

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -20,6 +20,7 @@ components:
         key-1: overwrite-value
         key-2: value-2
       auto_create_network: true
+# TODO: re-nenable services when billing is configured
 #      services:
 #        - service: container.googleapis.com
 #          disable_dependent_services: true


### PR DESCRIPTION
We do not have a valid `GCP_BILLING_ACCOUNT` secret set, so deployment tests fail because we enable services which require billing in the project creation tests (required by GKE tests). 
This PR is to temporarily remove the GKE deployment tests until a `GCP_BILLING_ACCOUNT` secret is set. It also no longer enables services which require billing when creating the projects