### PR TITLE
MPS-59 Fix Snyk recommendations for gke resources

### DIFF
--- a/Google/gke/cluster/node_pools.tf
+++ b/Google/gke/cluster/node_pools.tf
@@ -13,8 +13,8 @@ resource google_container_node_pool self {
   dynamic management {
     for_each = lookup(each.value, "management", null) == null ? {} : {management = each.value.management}
     content {
-      auto_upgrade = lookup(management.value, "auto_upgrade", null)
-      auto_repair = lookup(management.value, "auto_repair", null)
+      auto_upgrade = lookup(management.value, "auto_upgrade", true)
+      auto_repair = lookup(management.value, "auto_repair", true)
     }
   }
   dynamic node_config {


### PR DESCRIPTION
### Fixes
gke `cluster.tf`:
- SNYK-CC-TF-87: disabled legacy master_auth authentication
- SNYK-CC-TF-238: enable_private_nodes and enable_private_endpoint set to true by default
- SNYK-CC_TF-196: set network_policy.enabled to true
- SNYK-CC-TF-201: Add cluster resource_labels option

gke `node_pools.tf`:
- SNYK-CC-TF-195: Set auto_upgrade to true by default
- SNYK-CC-TF-232: Set auto_repair to true by default