### PR TITLE
Fix Workload Identity Federation output bug

### DIFF
--- a/Google/iam/workload_identity_federation/README.md
+++ b/Google/iam/workload_identity_federation/README.md
@@ -160,3 +160,11 @@ components:
             allowed_audiences:
               - 'default'
 ```
+
+## Outputs
+* `pool_id` - Map of pool IDs for each created pool. E.g.: 
+  ```hcl
+  pool_id = {
+    cicd = "projects/project-id/locations/global/workloadIdentityPools/cicd"
+  }
+  ```

--- a/Google/iam/workload_identity_federation/outputs.tf
+++ b/Google/iam/workload_identity_federation/outputs.tf
@@ -1,3 +1,3 @@
 output pool_id {
-  value = module.workload_identity_pools.pool_id
+  value = { for module, outputs in module.workload_identity_pools : module => lookup(outputs, "pool_id", null) }
 }

--- a/Google/resource-manager/project/README.md
+++ b/Google/resource-manager/project/README.md
@@ -1,6 +1,6 @@
 # Google Project Module  
 This module can be used to deploy Google Projects in a specified folder or organisation.
-This is created by defining a Terraform `module` which references a `yaml` configuration file (see [configuration](#google-project-basic-configuration)).
+This is created by defining a Terraform `module` which references a `yaml` configuration file (see [configuration](#google-project-basic-configuration).
 e.g. `main.tf`:
 ```terraform
 module dev_projects {
@@ -18,7 +18,7 @@ The following services must be enabled in the project which the deploying servic
 The account used for creating the project will need to have the following roles in the relevant folder/organization:
  * `roles/resourcemanager.projectCreator` for creating projects
  * `roles/resourcemanager.projectDeletor` for deleting projects
- * `roles/billing.user` for attaching a billing account to a project
+ * `roles/billing.user` for attaching a billing account to a project (can be applied to organization or individual billing accounts)
 
 And optionally:
  * `roles/resourcemanager.projectMover` for moving projects

--- a/Google/resource-manager/project/README.md
+++ b/Google/resource-manager/project/README.md
@@ -9,16 +9,21 @@ module dev_projects {
   #parent_folder = <dev-folder-id>   (optional) 
 }
 ```
-
+## Prerequisites
+### Required Services
+The following services must be enabled in the project which the deploying service account comes from:
+* `cloudbilling.googleapis.com`
+* `cloudresourcemanager.googleapis.com`
 ### Required Permissions
 The account used for creating the project will need to have the following roles in the relevant folder/organization:
  * `roles/resourcemanager.projectCreator` for creating projects
  * `roles/resourcemanager.projectDeletor` for deleting projects
+ * `roles/billing.user` for attaching a billing account to a project
 
 And optionally:
  * `roles/resourcemanager.projectMover` for moving projects
  * `roles/resourcemanager.projectIamAdmin` for managing the projects IAM policy
- * `roles/serviceusage.serviceUsageAdmin` for enabling services in the projects. 
+ * `roles/serviceusage.serviceUsageAdmin` for enabling services in the projects.
   This role can be assigned at the project level if necessary. 
 
 ## Google Project basic configuration  


### PR DESCRIPTION
There was an error with the format of the `pool_id` bug, causing module to fail. Have fixed this to be a map of pool id's.
Have also updated the Project module's README to include missing required services/roles