### PR TITLE
Develop - Workload Identity Federation Bug Fix & Snyk Alerts

### DIFF
--- a/Google/gke/cluster/node_pools.tf
+++ b/Google/gke/cluster/node_pools.tf
@@ -13,8 +13,8 @@ resource google_container_node_pool self {
   dynamic management {
     for_each = lookup(each.value, "management", null) == null ? {} : {management = each.value.management}
     content {
-      auto_upgrade = lookup(management.value, "auto_upgrade", null)
-      auto_repair = lookup(management.value, "auto_repair", null)
+      auto_upgrade = lookup(management.value, "auto_upgrade", true)
+      auto_repair = lookup(management.value, "auto_repair", true)
     }
   }
   dynamic node_config {

--- a/Google/iam/workload_identity_federation/README.md
+++ b/Google/iam/workload_identity_federation/README.md
@@ -160,3 +160,11 @@ components:
             allowed_audiences:
               - 'default'
 ```
+
+## Outputs
+* `pool_id` - Map of pool IDs for each created pool. E.g.: 
+  ```hcl
+  pool_id = {
+    cicd = "projects/project-id/locations/global/workloadIdentityPools/cicd"
+  }
+  ```

--- a/Google/iam/workload_identity_federation/outputs.tf
+++ b/Google/iam/workload_identity_federation/outputs.tf
@@ -1,3 +1,3 @@
 output pool_id {
-  value = module.workload_identity_pools.pool_id
+  value = { for module, outputs in module.workload_identity_pools : module => lookup(outputs, "pool_id", null) }
 }

--- a/Google/resource-manager/project/README.md
+++ b/Google/resource-manager/project/README.md
@@ -1,6 +1,6 @@
 # Google Project Module  
 This module can be used to deploy Google Projects in a specified folder or organisation.
-This is created by defining a Terraform `module` which references a `yaml` configuration file (see [configuration](#google-project-basic-configuration)).
+This is created by defining a Terraform `module` which references a `yaml` configuration file (see [configuration](#google-project-basic-configuration).
 e.g. `main.tf`:
 ```terraform
 module dev_projects {
@@ -18,7 +18,7 @@ The following services must be enabled in the project which the deploying servic
 The account used for creating the project will need to have the following roles in the relevant folder/organization:
  * `roles/resourcemanager.projectCreator` for creating projects
  * `roles/resourcemanager.projectDeletor` for deleting projects
- * `roles/billing.user` for attaching a billing account to a project
+ * `roles/billing.user` for attaching a billing account to a project (can be applied to organization or individual billing accounts)
 
 And optionally:
  * `roles/resourcemanager.projectMover` for moving projects

--- a/Google/resource-manager/project/README.md
+++ b/Google/resource-manager/project/README.md
@@ -9,16 +9,21 @@ module dev_projects {
   #parent_folder = <dev-folder-id>   (optional) 
 }
 ```
-
+## Prerequisites
+### Required Services
+The following services must be enabled in the project which the deploying service account comes from:
+* `cloudbilling.googleapis.com`
+* `cloudresourcemanager.googleapis.com`
 ### Required Permissions
 The account used for creating the project will need to have the following roles in the relevant folder/organization:
  * `roles/resourcemanager.projectCreator` for creating projects
  * `roles/resourcemanager.projectDeletor` for deleting projects
+ * `roles/billing.user` for attaching a billing account to a project
 
 And optionally:
  * `roles/resourcemanager.projectMover` for moving projects
  * `roles/resourcemanager.projectIamAdmin` for managing the projects IAM policy
- * `roles/serviceusage.serviceUsageAdmin` for enabling services in the projects. 
+ * `roles/serviceusage.serviceUsageAdmin` for enabling services in the projects.
   This role can be assigned at the project level if necessary. 
 
 ## Google Project basic configuration  


### PR DESCRIPTION
## Bug Fix
* Fix bug with Workload Identity Federation failing, due to `pool_id` being wrong format. `pool_id` output is now a map of Workload Identity Pools and their full IDs
## Changes
* Update GKE cluster and node pool modules to resolve Snyk Alerts
  * gke `cluster.tf`:
    - SNYK-CC-TF-87: disabled legacy master_auth authentication
    - SNYK-CC-TF-238: enable_private_nodes and enable_private_endpoint set to true by default
    - SNYK-CC_TF-196: set network_policy.enabled to true
    - SNYK-CC-TF-201: Add cluster resource_labels option
  * gke `node_pools.tf`:
    - SNYK-CC-TF-195: Set auto_upgrade to true by default
    - SNYK-CC-TF-232: Set auto_repair to true by default
 