### PR TITLE
Add destroy_duration for the project module time_sleep resource

### DIFF
--- a/Google/resource-manager/project/main.tf
+++ b/Google/resource-manager/project/main.tf
@@ -41,6 +41,7 @@ resource time_sleep self {
   count = local.enable_service_delay == null ? 0 : 1
   depends_on = [google_project_iam_policy.self]
   create_duration = local.enable_service_delay
+  destroy_duration = local.enable_service_delay
 }
 
 //noinspection HILUnresolvedReference


### PR DESCRIPTION
Currently deployment tests are failing to destroy project deployments due to conflict in updating the IAM policy. 

This is possibly due to there needing to be a timeout when destroying (i.e. disabling) services. When some of the services are disabled it might remove some IAM policy bindings, and when terraform attempts to remove destoy the google_project_iam_policy resource, it fails (https://github.com/mesoform/Multi-Cloud-Platform-Foundations/actions/runs/4822777280/jobs/8590419012).

Have added the `destroy_duration` setting to the `time_sleep` resource used for enabling services, so the delay should hopefully stop there being a conflict when updating/deleting the IAM policy