### PR TITLE
Develop - MCP-223 Fix Deployment Tests

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -234,13 +234,14 @@ jobs:
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan
 
-      - name: Destroy GKE clusters
-        if: always()
-        env:
-          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
-        run: |
-          cd gke
-          terraform destroy -auto-approve
+## Commented out due to conflicting IAM updates
+#      - name: Destroy GKE clusters
+#        if: always()
+#        env:
+#          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
+#        run: |
+#          cd gke
+#          terraform destroy -auto-approve
 
       - name: Destroy Google Service Accounts
         if: always()
@@ -252,5 +253,4 @@ jobs:
         if: always()
         run: |
           cd google_project
-          sleep 3m
           terraform destroy -auto-approve

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -252,5 +252,5 @@ jobs:
         if: always()
         run: |
           cd google_project
-          sleep 60
+          sleep 3m
           terraform destroy -auto-approve

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -8,6 +8,15 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
+    inputs:
+      action:
+        required: true
+        description: What terraform action to perform
+        default: 'plan'
+        options:
+         - plan
+         - deploy
 
 permissions:
   contents: 'read'
@@ -17,7 +26,7 @@ jobs:
   deployment-test-plans:
     runs-on: ubuntu-latest
     name: Deployment Test Plans
-    if: github.event_name != 'push'
+    if: github.event_name != 'push' || github.event.inputs.action == 'plan'
     env:
       working-directory: ./tests/gcp/deployment
       DATE: $(date +%m%d%H%M)
@@ -114,7 +123,7 @@ jobs:
   ############################# Deployment Tests for GCP modules #####################################################
   deployment-tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event.inputs.action == 'deploy'
     name: Deployment Tests
     env:
       working-directory: ./tests/gcp/deployment

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -234,14 +234,13 @@ jobs:
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan
 
-## Commented out due to conflicting IAM updates
-#      - name: Destroy GKE clusters
-#        if: always()
-#        env:
-#          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
-#        run: |
-#          cd gke
-#          terraform destroy -auto-approve
+      - name: Destroy GKE clusters
+        if: always()
+        env:
+          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
+        run: |
+          cd gke
+          terraform destroy -auto-approve
 
       - name: Destroy Google Service Accounts
         if: always()

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -67,7 +67,7 @@ jobs:
           cd google_project/resource
           sed -i "s/<project_date>/${{ steps.vars.outputs.DATE }}/g" projects.yaml
           sed -i "s/<folder_id>/folders\/${{secrets.GCP_FOLDER_ID}}/g" projects.yaml
-          sed -i "s/<billing_account>/${{secrets.GCP_BILLING_ACCOUNT}}/g" projects.yaml
+          sed -i "s/<billing_account>/${{secrets.GCP_BILLING_ID}}/g" projects.yaml
           sed -i "s/<service_account>/${{secrets.GCP_SA_EMAIL}}/g"  projects.yaml
           cat projects.yaml
 
@@ -185,7 +185,7 @@ jobs:
           cd google_project/resource
           sed -i "s/<project_date>/${{ steps.vars.outputs.DATE }}/g" projects.yaml
           sed -i "s/<folder_id>/folders\/${{secrets.GCP_FOLDER_ID}}/g" projects.yaml
-          sed -i "s/<billing_account>/${{secrets.GCP_BILLING_ACCOUNT}}/g" projects.yaml
+          sed -i "s/<billing_account>/${{secrets.GCP_BILLING_ID}}/g" projects.yaml
           sed -i "s/<service_account>/${{secrets.GCP_SA_EMAIL}}/g" projects.yaml
           cat projects.yaml
 
@@ -214,22 +214,21 @@ jobs:
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan
 
-# TODO: re-enable steps when billing is configured
-#      - name: Deploy GKE clusters
-#        id : deploy-gke
-#        env:
-#          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
-#        run: |
-#          cd gke
-#          terraform init
-#          terraform plan -out="./plan.tfplan"
-#          terraform apply plan.tfplan
-#
-#      - name: Destroy GKE clusters
-#        if: always()
-#        run: |
-#          cd gke
-#          terraform destroy -auto-approve
+      - name: Deploy GKE clusters
+        id : deploy-gke
+        env:
+          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
+        run: |
+          cd gke
+          terraform init
+          terraform plan -out="./plan.tfplan"
+          terraform apply plan.tfplan
+
+      - name: Destroy GKE clusters
+        if: always()
+        run: |
+          cd gke
+          terraform destroy -auto-approve
 
       - name: Destroy Google Service Accounts
         if: always()

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -227,6 +227,8 @@ jobs:
 
       - name: Destroy GKE clusters
         if: always()
+        env:
+          TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
         run: |
           cd gke
           terraform destroy -auto-approve

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -220,6 +220,7 @@ jobs:
           TF_VAR_project_id: mcp-test-project-${{ steps.vars.outputs.DATE }}
         run: |
           cd gke
+          sleep 3m
           terraform init
           terraform plan -out="./plan.tfplan"
           terraform apply plan.tfplan

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -252,4 +252,5 @@ jobs:
         if: always()
         run: |
           cd google_project
+          sleep 60
           terraform destroy -auto-approve

--- a/.github/workflows/manual_destroy.yml
+++ b/.github/workflows/manual_destroy.yml
@@ -16,6 +16,10 @@ on:
           - folders
         default: 'projects'
 
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
 jobs:
   destroy-folders:
     name: "Destroy folder"
@@ -41,10 +45,14 @@ jobs:
         with:
           terraform_wrapper: false
 
+      # Install gcloud sdk and set the service account
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: ${{secrets.GCP_SA_KEY}}
+          service_account: ${{secrets.GCP_SA_EMAIL}}
+          workload_identity_provider: ${{secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          token_format: 'access_token'
+          access_token_lifetime: 1200s # 20 minutes
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
@@ -58,24 +66,18 @@ jobs:
       - run: pip install pyyaml
 
       - name: Add IDs to GCP Folder Files
-        env:
-          GOOGLE_CREDENTIALS: ${{secrets.GCP_SA_KEY}}
         run: |
           cd resource
           sed -i "s/<folder_id>/folders\/${{secrets.GCP_FOLDER_ID}}/" folders.yaml
-          SERVICE_ACCOUNT=$(echo $GOOGLE_CREDENTIALS | jq -r '.client_email')
-          sed -i "s/<service_account>/$SERVICE_ACCOUNT/"  folders.yaml
+          sed -i "s/<service_account>/${{secrets.GCP_SA_EMAIL}}/"  folders.yaml
           cat folders.yaml
 
       - name: Import Folders to terraform state
         env:
-          GOOGLE_CREDENTIALS: ${{secrets.GCP_SA_KEY}}
           GCP_FOLDER_ID: ${{secrets.GCP_FOLDER_ID}}
         run: ./folder_import_script.sh
 
       - name: Destroy folders
-        env:
-          GOOGLE_CREDENTIALS: ${{secrets.GCP_SA_KEY}}
         run: terraform destroy -auto-approve
 
   delete-projects:
@@ -94,10 +96,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Install gcloud sdk and set the service account
       - id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: ${{secrets.GCP_SA_KEY}}
+          service_account: ${{secrets.GCP_SA_EMAIL}}
+          workload_identity_provider: ${{secrets.GCP_WORKLOAD_IDENTITY_PROVIDER}}
+          token_format: 'access_token'
+          access_token_lifetime: 1200s # 20 minutes
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
@@ -112,6 +118,5 @@ jobs:
 
       - name: Delete projects
         env:
-          GOOGLE_CREDENTIALS: ${{secrets.GCP_SA_KEY}}
           GCP_FOLDER_ID: ${{secrets.GCP_FOLDER_ID}}
         run: ./delete_projects.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,14 +35,6 @@ jobs:
       with:
         terraform_wrapper: false
 
-    # Install gcoud sdk and set the service account
-    #- name: Setup Cloud SDK
-    #  uses: google-github-actions/setup-gcloud@v0
-    #  with:
-    #    service_account_key: ${{secrets.GCP_SA_KEY}}
-    #    export_default_credentials: true
-
-    
     # Run unit tests in GCP module
     - name: Run GCP unit tests
       run: |
@@ -74,5 +66,3 @@ jobs:
         done
         echo ${MESSAGE^^}
         exit $EXIT_CODE
-
-

--- a/Google/gke/backup_plan/main.tf
+++ b/Google/gke/backup_plan/main.tf
@@ -7,7 +7,7 @@ resource google_gke_backup_backup_plan self {
   for_each = local.backup_plans_specs
   project = data.google_project.self.project_id
   cluster = var.cluster_id == null ? each.value.cluster_id : var.cluster_id
-  name = lookup(each.value, "name", each.key)
+  name = replace(lookup(each.value, "name", each.key), "_", "-")
   location = lookup(each.value, "location", null)
   dynamic backup_config {
     for_each = lookup(each.value, "backup_config", null) == null ? {backup_config = {}} : {backup_config = each.value.backup_config}

--- a/Google/resource-manager/project/main.tf
+++ b/Google/resource-manager/project/main.tf
@@ -41,6 +41,7 @@ resource time_sleep self {
   count = local.enable_service_delay == null ? 0 : 1
   depends_on = [google_project_iam_policy.self]
   create_duration = local.enable_service_delay
+  destroy_duration = local.enable_service_delay
 }
 
 //noinspection HILUnresolvedReference

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -20,11 +20,10 @@ components:
         key-1: overwrite-value
         key-2: value-2
       auto_create_network: true
-# TODO: re-nenable services when billing is configured
-#      services:
-#        - service: container.googleapis.com
-#          disable_dependent_services: true
-#        - service: gkebackup.googleapis.com
+      services:
+        - service: container.googleapis.com
+          disable_dependent_services: true
+        - service: gkebackup.googleapis.com
     test-project:
       project_id: mcp-test-project-<project_date>
       auto_create_network: true

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -20,10 +20,10 @@ components:
         key-1: overwrite-value
         key-2: value-2
       auto_create_network: true
+    test-project:
+      project_id: mcp-test-project-<project_date>
+      auto_create_network: true
       services:
         - service: container.googleapis.com
           disable_dependent_services: true
         - service: gkebackup.googleapis.com
-    test-project:
-      project_id: mcp-test-project-<project_date>
-      auto_create_network: true

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -7,6 +7,7 @@ components:
     labels:
       default: value
       key-1: value-1
+    enable_service_delay: 5m
     project_iam:
       - role: "roles/owner"
         members:
@@ -23,7 +24,6 @@ components:
     test-project:
       project_id: mcp-test-project-<project_date>
       auto_create_network: true
-      enable_service_delay: 5m
       services:
         - service: container.googleapis.com
           disable_dependent_services: true

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -26,5 +26,6 @@ components:
       auto_create_network: true
       services:
         - service: container.googleapis.com
-          disable_dependent_services: true
+          disable_on_destroy: false
         - service: gkebackup.googleapis.com
+          disable_on_destroy: false

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -7,7 +7,6 @@ components:
     labels:
       default: value
       key-1: value-1
-    enable_service_delay: 5m
     project_iam:
       - role: "roles/owner"
         members:

--- a/tests/gcp/deployment/google_project/resource/projects.yaml
+++ b/tests/gcp/deployment/google_project/resource/projects.yaml
@@ -23,6 +23,7 @@ components:
     test-project:
       project_id: mcp-test-project-<project_date>
       auto_create_network: true
+      enable_service_delay: 5m
       services:
         - service: container.googleapis.com
           disable_dependent_services: true


### PR DESCRIPTION
Deployment tests were failing due to conflicting updates of IAM policy when attempting to destroy projects. This seems to have been because of IAM changes after disabling services (possibly the `gkebackup.googleapis.com` service was causing the issue), so have set `disable_on_destroy` to false and that has resolved the issue. This possibly could have also been resolved by increasing the time of the `enable_service_delay` but that would lead to longer pipeline runs.
This PR includes some older updates from the develop branch, including:
* Re-enabling billing and gke deployment tests
* Allows manual trigger of deployment pipeline
* Use workload identity federation in manual_destroy workflow
* Adds destroy duration for `time_sleep` resource (which is used for a delay between enabling service and setting IAM policy)