### PR TITLE
patch/bump_provider_project

### DIFF
--- a/Google/resource-manager/project/provider.tf
+++ b/Google/resource-manager/project/provider.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">=3.55.0, <4.0.0"
+      version = ">=3.55.0, <5.0.0"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">=3.55.0, <4.0.0"
+      version = ">=3.55.0, <5.0.0"
     }
   }
 }


### PR DESCRIPTION
There is a conflict when using different resources on the same module with google provider versions clashing with each other:
e.g:
      version = ">=4.0.0, <5.0.0"  VS version = ">=3.55.0, <4.0.0"
as in
https://github.com/mesoform/Multi-Cloud-Platform-Foundations/blob/main/Google/cloud_dns/record_set/provider.tf
