### PR TITLE
change folder condition expression default

### DIFF
--- a/Google/resource-manager/folder/main.tf
+++ b/Google/resource-manager/folder/main.tf
@@ -23,7 +23,7 @@ data "google_iam_policy" "self" {
         content {
           title       = lookup(condition.value, "title", null)
           description = lookup(condition.value, "description", null)
-          expression  = lookup(condition.value, "expression", {condition = null})
+          expression  = lookup(condition.value, "expression", null)
         }
       }
     }


### PR DESCRIPTION
Getting this error
```
+ terraform plan -lock-timeout=120s
module.folder.google_folder.self["development"]: Refreshing state... [id=$IMPORT_DEVELOPMENT_DEVELOPMENT]
module.sub_folders[0].google_folder.self["testing"]: Refreshing state... [id=$IMPORT_DEVELOPMENT_TESTING]
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/folder/Google/resource-manager/folder/main.tf line 26, in data "google_iam_policy" "self":
│   26:           expression  = lookup(condition.value, "expression", {condition = null})
│ 
│ Invalid value for "default" parameter: the default value must have the same
│ type as the map elements.
```

and doesn’t exist on https://github.com/mesoform/Multi-Cloud-Platform-Foundations/blob/main/Google/resource-manager/project/main.tf#L33 